### PR TITLE
Add windows compatibility for retrieving configuration directories

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,7 @@ exports.homedir = function() {
   return process.env['USERPROFILE'];
 }
 
+exports.configdir =
 exports.datadir = function(p) {
   var appData = process.env['LOCALAPPDATA'] || process.env['APPDATA']
   return appData + "\\" + p;
@@ -108,6 +109,5 @@ exports.tmpdir =
 exports.tempdir = function() {
   return process.env['TEMP'];
 }
-
 
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,4 +110,5 @@ exports.tempdir = function() {
   return process.env['TEMP'];
 }
 
+
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,8 @@ exports.homedir = function() {
 exports.configdir =
 exports.datadir = function(p) {
   var appData = process.env['LOCALAPPDATA'] || process.env['APPDATA']
-  return appData + "\\" + p;
+  return p ? path.join(appData, p)
+           : path.join(appData);
 }
 
 exports.tmpdir =


### PR DESCRIPTION
Unless I am mistaken, there is no system level differentiation between data and configuration data in Windows 9/10. So, I have merely aliased the method.

I held off on repeating the gesture for cache, and log, as I would expect there to be a real place somewhere in this filesystem for caches and logs.
